### PR TITLE
Add useful prefixes to the web client log messages.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
-* Add log prefixes to web log.
 * Review log messages and levels.
+* Add "mark log" feature to web client.
 * Improve player manager level() call handling.
 * Review code for consistency (naming, etc).
 * Update movie files.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 * Review log messages and levels.
-* Add "mark log" feature to web client.
 * Improve player manager level() call handling.
 * Review code for consistency (naming, etc).
 * Update movie files.

--- a/candle2017.py
+++ b/candle2017.py
@@ -85,7 +85,7 @@ def start_things(reactor, settings):
     )
 
     # Connect the log bridge to the raw listener.
-    log_bridge.destination = raw_listener
+    log_bridge.destination_callable = raw_listener.log_message
 
     # Read: start the player manager.
     yield player_manager.start()

--- a/log/bridge.py
+++ b/log/bridge.py
@@ -8,6 +8,8 @@
 Helps bridging Twisted log messages towads runtime configurable destinations.
 """
 
+from datetime import datetime
+
 from zope.interface import provider
 from twisted.logger import ILogObserver, formatEvent
 
@@ -29,10 +31,23 @@ class LogBridge(object):
     def __call__(self, event):
 
         # Called by Twisted to deliver a log event to this observer.
+        # Details about `event` and more at:
+        # http://twistedmatrix.com/documents/current/core/howto/logger.html
 
         # TODO: Convert `destination` into a simple callable?
         if self.destination:
-            msg = formatEvent(event)
+            # Formatted messages contain four elements, space separated:
+            # - Capitalized first letter of log level.
+            # - Seconds and milliseconds of event timestamp.
+            # - The logger namespace (variable width).
+            # - The formatted log message itself.
+            log_datetime = datetime.fromtimestamp(event['log_time'])
+            msg = '%s %s %s %s' % (
+                event['log_level'].name[0].upper(),
+                log_datetime.strftime('%S.%f')[:6],
+                event.get('log_namespace', '-'),
+                formatEvent(event),
+            )
             self.destination.log_message(msg)
 
 

--- a/log/bridge.py
+++ b/log/bridge.py
@@ -11,11 +11,11 @@ Helps bridging Twisted log messages towads runtime configurable destinations.
 from datetime import datetime
 
 from zope.interface import provider
-from twisted.logger import ILogObserver, formatEvent
+from twisted import logger
 
 
 
-@provider(ILogObserver)
+@provider(logger.ILogObserver)
 class LogBridge(object):
 
     """
@@ -46,7 +46,7 @@ class LogBridge(object):
                 event['log_level'].name[0].upper(),
                 log_datetime.strftime('%S.%f')[:6],
                 event.get('log_namespace', '-'),
-                formatEvent(event),
+                logger.formatEvent(event),
             )
             self.destination.log_message(msg)
 

--- a/log/bridge.py
+++ b/log/bridge.py
@@ -19,14 +19,15 @@ from twisted import logger
 class LogBridge(object):
 
     """
-    Twisted logger observer that forwards emitted logs towards a configurable
-    `destination` object that should have a `log_message` method.
+    Twisted logger observer that forwards emitted logs to a callable, accepting
+    a string as its single argument.
     """
 
-    def __init__(self):
+    def __init__(self, destination_callable=None):
 
         # Where we'll forward log messages to.
-        self.destination = None
+        self.destination_callable = destination_callable
+
 
     def __call__(self, event):
 
@@ -34,13 +35,14 @@ class LogBridge(object):
         # Details about `event` and more at:
         # http://twistedmatrix.com/documents/current/core/howto/logger.html
 
-        # TODO: Convert `destination` into a simple callable?
-        if self.destination:
+        if self.destination_callable:
+
             # Formatted messages contain four elements, space separated:
-            # - Capitalized first letter of log level.
-            # - Seconds and milliseconds of event timestamp.
-            # - The logger namespace (variable width).
-            # - The formatted log message itself.
+            # - Fixed width, capitalized first letter of log level.
+            # - Fixed width, seconds and milliseconds of event timestamp.
+            # - Variable width, logger namespace.
+            # - Variable width, formatted message itself.
+
             log_datetime = datetime.fromtimestamp(event['log_time'])
             msg = '%s %s %s %s' % (
                 event['log_level'].name[0].upper(),
@@ -48,7 +50,7 @@ class LogBridge(object):
                 event.get('log_namespace', '-'),
                 logger.formatEvent(event),
             )
-            self.destination.log_message(msg)
+            self.destination_callable(msg)
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Now includes:
* Log level.
* Timestamp.
* Logger namespace.
* The log message itself.

Trying to save horizontal horizontal space, log level is represented as the capitalized first letter ('D', 'I', 'W', 'E') and timestamp includes only seconds and milliseconds.

Initial observation suggests that logger namespaces and messages should be reviewed for horizontal compactness while being readable and useful. :)