### PR TITLE
Improved player stop: DBus stop request failures handled via SIGTERM.

### DIFF
--- a/player/player_manager.py
+++ b/player/player_manager.py
@@ -202,12 +202,8 @@ class PlayerManager(object):
         self._stopping = True
         for level, player in self.players.items():
             self.log.info('stopping player level={l!r}', l=level)
-            try:
-                yield player.stop()
-            except Exception as e:
-                self.log.info('failed stopping player level={l!r}: {e!r}', l=level, e=e)
-            else:
-                self.log.info('stopped player level={l!r}', l=level)
+            yield player.stop()
+            self.log.info('stopped player level={l!r}', l=level)
         self.log.info('stopped')
         self.done.callback(None)
 


### PR DESCRIPTION
(because I ... just ... couldn't ... stop ... thinking ... about ... it ... *sigh!*)

Refactored and extended player stop code:
* Handles DBus stop request failures by falling back to sending SIGTERM signals to the process.
* Better log messages and conditionals.
* Bonus: simplified player manager stop code.

Addresses #31.

PS: My investigation included [forking DBus](https://github.com/tmontes/dbus) and creating a better `dbus-run-session` tool, but that's a whole other story!!!
