### PR TITLE
Revamp DBus infrastructure dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Most settings are, hopefully, self-explanatory. Here's a quick rundown:
 
 | setting                          | description                                                     |
 |----------------------------------|-----------------------------------------------------------------|
-| environment.dbus_run_session_bin | Absolute path to the `dbus-run-session` executable.
+| environment.dbus_daemon_bin      | Absolute path to the `dbus-daemon` executable.
 | environment.omxplayer_bin        | Absolute path to the `omxplayer.bin` executable.                |
 | environment.ld_library_path      | Absolute path to the OMXPlayer required shared libraries.       |
 | loglevel                         | Default log level, one of `debug`, `info`, `warn` or `error`.   |

--- a/candle2017.service
+++ b/candle2017.service
@@ -24,13 +24,6 @@ Wants=network.target
 
 [Service]
 
-; Technical note
-; --------------
-; - candle2017.py defaults to using the system dbus-run-session binary.
-; - This has some implications in the way a controlled stop happens.
-; - If you want to know more, read the next Technical note, below.
-; - Otherwise, just fill in the placeholders and disregard that.
-
 ; Placeholder description
 ; -----------------------
 ; - {USERNAME_OR_ID}
@@ -43,57 +36,16 @@ Wants=network.target
 ;   The absolute path to python3 in the created virtual environment.
 ; - {candle2017.py_ABSPATH}
 ;   The absolute path to candle2017.py.
-; - {USERNAME}
-;   The same as above, in {USERNAME_OR_ID}, unless a user ID number was used.
-;   This must be a username, even if it includes ".".
 
 Type=simple
 User={USERNAME_OR_ID}
 WorkingDirectory={USER_HOME}
 ExecStart={VENV_PYTHON3_ABSPATH} {candle2017.py_ABSPATH}
-ExecStop=/usr/bin/killall -u {USERNAME} python3
-KillMode=none
+KillMode=process
+KillSignal=SIGTERM
 TimeoutStopSec=10
 Restart=always
 RestartSec=10
-
-
-; Technical note
-; --------------
-; The system dbus-run-session binary behaves somewhat badly:
-; - If sent a SIGTERM:
-;   - It terminates.
-;   - Leaves two orphans: dbus-daemon and the launched application.
-; - This is somewhat useless and the reason that the stop is setup the way
-;   it is in the previous, uncommented, unfortunatelly recommended section.
-;
-; A better behaving dbus-run-session would:
-; - If sent a SIGTERM:
-;   - Forward it to the launched application.
-;   - Wait for it to exit.
-;   - Stop its dbus-daemon child.
-;   - Wait for it to exit.
-;   - Finally exit.
-; - This would allow stopping everything cleanly by sending dbus-run-session
-;   a single SIGTERM signal; this could be achieved with the following,
-;   commented out, section.
-;
-; PS: For an unofficial fork of dbus with a better behaving dbus-run-session,
-;     see https://github.com/tmontes/dbus/tree/better-dbus-run-session.
-;
-; PPS: Of, course, leaving out any of the "stop service" settings does also
-;      work in the sense that things a stopped; they're just not stopped in
-;      a clean and synchronized way (and that is ugly).
-
-; Type=simple
-; User={USERNAME_OR_ID}
-; WorkingDirectory={USER_HOME}
-; ExecStart={VENV_PYTHON3_ABSPATH} {candle2017.py_ABSPATH}
-; KillMode=process
-; KillSignal=SIGTERM
-; TimeoutStopSec=10
-; Restart=always
-; RestartSec=10
 
 
 

--- a/player/dbus_manager.py
+++ b/player/dbus_manager.py
@@ -8,27 +8,37 @@
 Asyncrounous, Twisted Based, DBus connection setup and name tracking.
 """
 
+import os
+
 from twisted.internet import defer
 from twisted import logger
 
 from txdbus import client as txdbus_client
+
+from . import process
 
 
 
 class DBusManager(object):
 
     """
-    Connects to DBus and tracks object names showing up/going away.
+    Manages a private DBus instance by spawning a child DBus daemon,
+    connecting to it and tracking object names showing up/going away.
     """
 
-    def __init__(self, reactor):
+    def __init__(self, reactor, settings):
 
         self.reactor = reactor
         self.log = logger.Logger(namespace='player.dbus')
 
+        # Will be set once the private DBus process is spawned.
+        self._dbus_daemon_bin = settings['environment']['dbus_daemon_bin']
+        self._dbus_proto = None
+
+        # Our connection to DBus.
         self._dbus_conn = None
 
-        # Will be called on disconnect.
+        # Will be called on DBus disconnect.
         self._disconnect_callable = None
 
         # keys/values: DBus names/Twisted deferreds
@@ -52,6 +62,9 @@ class DBusManager(object):
         """
         Connects to DBus and sets up DBus object name tracking.
         """
+        if not self._dbus_proto:
+            yield self._spawn_dbus_daemon()
+
         self.log.info('connecting to dbus')
         self._dbus_conn = yield txdbus_client.connect(self.reactor, bus_address)
         self.log.info('connected to dbus')
@@ -73,6 +86,40 @@ class DBusManager(object):
             self._dbus_signal_name_owner_changed
         )
         self.log.debug('subscribed to NameOwnerChanged signal')
+
+
+    @defer.inlineCallbacks
+    def _spawn_dbus_daemon(self):
+
+        # Spawns a child DBus daemon, reads its address from its stdout and
+        # sets the DBUS_SESSION_BUS_ADDRESS environment variable (so that we
+        # and our child processes can connect to it).
+
+        self.log.info('spawning dbus daemon {ddb!r}', ddb=self._dbus_daemon_bin)
+        self._dbus_proto = process.spawn(
+            self.reactor,
+            [self._dbus_daemon_bin, '--session', '--print-address', '--nofork'],
+            'dbus-daemon',
+            track_output=True,
+        )
+        self.log.debug('waiting for dbus daemon start')
+        yield self._dbus_proto.started
+        self.log.debug('dbus daemon started')
+
+        # Get the first line of output, containing the bus address.
+        output_data = None
+        try:
+            output_deferred = self._dbus_proto.out_queue.get()
+            output_deferred.addTimeout(5, self.reactor)
+            output_data = yield output_deferred
+            output_text = output_data.decode('utf-8')
+            output_lines = output_text.split('\n')
+            bus_address = output_lines[0]
+        except Exception as e:
+            self.log.error('bad dbus daemon output {o!r}: {e!r}', o=output_data, e=e)
+            raise
+        else:
+            os.environ['DBUS_SESSION_BUS_ADDRESS'] = bus_address
 
 
     def _dbus_disconnected(self, _dbus_conn, failure):

--- a/player/dbus_manager.py
+++ b/player/dbus_manager.py
@@ -133,13 +133,14 @@ class DBusManager(object):
             self.log.info('nothing to cleanup')
             return
 
+        self.log.info('signalling dbus daemon termination')
         try:
-            self.log.info('signalling dbus daemon termination')
             self._dbus_proto.terminate()
-            self.log.info('signalled dbus daemon termination')
         except OSError as e:
-            self.log.info('signalling dbus daemon failed: {e!r}', e=e)
+            self.log.warn('signalling dbus daemon failed: {e!r}', e=e)
             raise
+        else:
+            self.log.info('signalled dbus daemon termination')
 
         self.log.debug('waiting for dbus daemon termination')
         yield self._dbus_proto.stopped

--- a/player/dbus_manager.py
+++ b/player/dbus_manager.py
@@ -122,6 +122,32 @@ class DBusManager(object):
             os.environ['DBUS_SESSION_BUS_ADDRESS'] = bus_address
 
 
+    @defer.inlineCallbacks
+    def cleanup(self):
+        """
+        Ensures the spawned DBus daemon is properly stopped.
+        """
+        self.log.info('cleaning up')
+
+        if not self._dbus_proto:
+            self.log.info('nothing to cleanup')
+            return
+
+        try:
+            self.log.info('signalling dbus daemon termination')
+            self._dbus_proto.terminate()
+            self.log.info('signalled dbus daemon termination')
+        except OSError as e:
+            self.log.info('signalling dbus daemon failed: {e!r}', e=e)
+            raise
+
+        self.log.debug('waiting for dbus daemon termination')
+        yield self._dbus_proto.stopped
+        self.log.debug('dbus daemon terminated')
+
+        self.log.info('cleaned up')
+
+
     def _dbus_disconnected(self, _dbus_conn, failure):
 
         # Called by txdbus when DBus is disconnected.

--- a/player/player.py
+++ b/player/player.py
@@ -335,13 +335,13 @@ class OMXPlayer(object):
             self.log.info('no player {p!r} process to send signal to', p=player_name)
             return
 
-        self.log.debug('sending SIGTERM to process')
+        self.log.debug('signalling process termination')
         try:
-            os.kill(self._process_protocol.pid, signal.SIGTERM)
-        except Exception as e:
-            self.log.warn('sending SIGTERM failed: {e!r}', e=e)
+            self._process_protocol.terminate()
+        except OSError as e:
+            self.log.warn('signalling process failed: {e!r}', e=e)
         else:
-            self.log.debug('sent SIGTERM to process')
+            self.log.debug('signalled process termination')
 
         # Finally, wait for the process to end, discarding the exit code.
         yield self._process_protocol.stopped

--- a/player/player.py
+++ b/player/player.py
@@ -11,10 +11,9 @@ Asyncronous, Twisted based, omxplayer process wrapper.
 
 import os
 import random
-import signal
 from time import time
 
-from twisted.internet import defer, protocol
+from twisted.internet import defer
 from twisted import logger
 
 from txdbus import error, interface as txdbus_interface
@@ -327,13 +326,6 @@ class OMXPlayer(object):
     def _stop_via_sigterm(self):
 
         # Sends a SIGTERM to the spawned process and waits for it to exit.
-
-        player_name = self.dbus_player_name
-
-        if self._process_protocol.stopped.called:
-            # Prevent race condition: do nothing if process is gone.
-            self.log.info('no player {p!r} process to send signal to', p=player_name)
-            return
 
         self.log.debug('signalling process termination')
         try:

--- a/player/player.py
+++ b/player/player.py
@@ -19,58 +19,8 @@ from twisted import logger
 
 from txdbus import error, interface as txdbus_interface
 
-
+from . import process
 from .misc import sleep
-
-
-
-class _TrackProcessProtocol(protocol.ProcessProtocol):
-
-    """
-    Twisted ProcessProtocol class used to track process startup/exit.
-    Exposes two relevant attributes:
-    - `started`: deferred that fires when the associated process is started.
-    - `stopped`: deferred that fires when the associated process terminates.
-    """
-
-    def __init__(self, player_name):
-
-        self.log = logger.Logger(namespace='player.proc.%s' % (player_name,))
-        self.started = defer.Deferred()
-        self.stopped = defer.Deferred()
-        self.pid = None
-
-
-    def connectionMade(self):
-
-        # Called by Twisted when the process is started.
-
-        self.pid = self.transport.pid
-        self.log.info('player process started with PID {pid}', pid=self.pid)
-        self.started.callback(None)
-
-
-    def outReceived(self, data):
-
-        # Called by Twisted when the process writes to its standard output.
-
-        self.log.debug('stdout: {s!r}', s=data)
-
-
-    def errReceived(self, data):
-
-        # Called by Twisted when the process writes to its standard error.
-
-        self.log.warn('stderr: {s!r}', s=data)
-
-
-    def processEnded(self, reason):
-
-        # Called by Twisted when the process terminates.
-
-        exit_code = reason.value.exitCode
-        self.log.info('player process ended; exit_code={ec!r}', ec=exit_code)
-        self.stopped.callback(exit_code)
 
 
 
@@ -115,9 +65,6 @@ class OMXPlayer(object):
 
         # Used to track omxplayer process startup/termination.
         self._process_protocol = None
-
-        # TODO: Not really used, can go away.
-        self._process_transport = None
 
         # DBus proxy object for the player: used to control it.
         self._dbus_player = None
@@ -218,7 +165,6 @@ class OMXPlayer(object):
 
         # Spawn the omxplayer.bin process.
 
-        self._process_protocol = _TrackProcessProtocol(self.dbus_player_name)
         args = [self.player_mgr.executable]
         if self.loop:
             args.append('--loop')
@@ -229,14 +175,10 @@ class OMXPlayer(object):
         args.extend(('--alpha', str(self.alpha)))
         args.append(str(self.filename))
 
-        # env=None, below, is relevant: it ensures that environment variables
-        # this process has set are passed down to the child process; in this
-        # case, PlayerManager probably set LD_LIBRARY_PATH.
-        self._process_transport = self._reactor.spawnProcess(
-            self._process_protocol,
-            self.player_mgr.executable,
+        self._process_protocol = process.spawn(
+            self._reactor,
             args,
-            env=None,
+            self.dbus_player_name,
         )
 
 

--- a/player/player_manager.py
+++ b/player/player_manager.py
@@ -141,7 +141,7 @@ class PlayerManager(object):
     @defer.inlineCallbacks
     def _dbus_disconnected(self):
 
-        # Called by DBus manager /when DBus connection is lost.
+        # Called by DBus manager when DBus connection is lost.
 
         if self._stopping:
             return
@@ -223,6 +223,9 @@ class PlayerManager(object):
             self.log.info('stopping player level={l!r}', l=level)
             yield player.stop(skip_dbus)
             self.log.info('stopped player level={l!r}', l=level)
+        self.log.info('cleaning up dbus manager')
+        yield self.dbus_mgr.cleanup()
+        self.log.info('cleaned up dbus manager')
         self._ready = False
 
         self.log.info('stopped')

--- a/player/player_manager.py
+++ b/player/player_manager.py
@@ -51,8 +51,9 @@ class PlayerManager(object):
 
         self.reactor = reactor
         self.settings = settings
+
         # part of our public interface, OMXPlayer will use this
-        self.dbus_mgr = DBusManager(reactor)
+        self.dbus_mgr = DBusManager(reactor, settings)
 
         # keys/values: integer levels/list of video files
         self.files = {}

--- a/player/process.py
+++ b/player/process.py
@@ -8,7 +8,7 @@
 Asyncrounous, Twisted Based, process management.
 """
 
-from twisted.internet import defer, protocol
+from twisted.internet import defer, protocol, error
 from twisted import logger
 
 
@@ -64,6 +64,20 @@ class _TrackProcessProtocol(protocol.ProcessProtocol):
         self.log.debug('{n} stderr: {d!r}', n=self.name, d=data)
         if self._track_output:
             self.err_queue.put(data)
+
+
+    def terminate(self):
+        """
+        Sends a SIGTERM to the process.
+
+        May raise an OSError.
+        """
+        try:
+            self.log.debug('sending SIGTERM to {n}', n=self.name)
+            self.transport.signalProcess('TERM')
+            self.log.debug('sent SIGTERM to {n}', n=self.name)
+        except error.ProcessExitedAlready:
+            self.log.debug('{n} already exited', n=self.name)
 
 
     def processEnded(self, reason):

--- a/player/process.py
+++ b/player/process.py
@@ -29,7 +29,6 @@ class _TrackProcessProtocol(protocol.ProcessProtocol):
 
     def __init__(self, name, track_output=False):
 
-        self.name = name
         self.log = logger.Logger(namespace='player.proc.%s' % (name,))
         self.started = defer.Deferred()
         self.stopped = defer.Deferred()
@@ -44,7 +43,7 @@ class _TrackProcessProtocol(protocol.ProcessProtocol):
         # Called by Twisted when the process is started.
 
         self.pid = self.transport.pid
-        self.log.info('{n} process started, PID {p}', n=self.name, p=self.pid)
+        self.log.info('process started, PID {p}', p=self.pid)
         self.started.callback(self.pid)
 
 
@@ -52,7 +51,7 @@ class _TrackProcessProtocol(protocol.ProcessProtocol):
 
         # Called by Twisted when the process writes to its standard output.
 
-        self.log.debug('{n} stdout: {d!r}', n=self.name, d=data)
+        self.log.debug('stdout: {d!r}', d=data)
         if self._track_output:
             self.out_queue.put(data)
 
@@ -61,7 +60,7 @@ class _TrackProcessProtocol(protocol.ProcessProtocol):
 
         # Called by Twisted when the process writes to its standard error.
 
-        self.log.debug('{n} stderr: {d!r}', n=self.name, d=data)
+        self.log.debug('stderr: {d!r}', d=data)
         if self._track_output:
             self.err_queue.put(data)
 
@@ -73,11 +72,11 @@ class _TrackProcessProtocol(protocol.ProcessProtocol):
         May raise an OSError.
         """
         try:
-            self.log.debug('sending SIGTERM to {n}', n=self.name)
+            self.log.debug('sending SIGTERM')
             self.transport.signalProcess('TERM')
-            self.log.debug('sent SIGTERM to {n}', n=self.name)
+            self.log.debug('sent SIGTERM')
         except error.ProcessExitedAlready:
-            self.log.debug('{n} already exited', n=self.name)
+            self.log.debug('already exited')
 
 
     def processEnded(self, reason):
@@ -85,7 +84,7 @@ class _TrackProcessProtocol(protocol.ProcessProtocol):
         # Called by Twisted when the process terminates.
 
         exit_code = reason.value.exitCode
-        self.log.info('{n} process ended, exit code {ec}', n=self.name, ec=exit_code)
+        self.log.info('process ended, exit code {ec}', ec=exit_code)
         self.stopped.callback(exit_code)
 
 

--- a/player/process.py
+++ b/player/process.py
@@ -76,18 +76,21 @@ class _TrackProcessProtocol(protocol.ProcessProtocol):
 
 
 
-def spawn(reactor, cmd_args, name):
+def spawn(reactor, cmd_args, name, track_output=False):
 
     """
     Simple wrapper around Twisted's IReactorProcess.spawnProcess.
 
     Assumes the executable is the first entry in `cmd_args` and ensures
-    the current process environment is passed down to the spawned process.
+    the current process environment is passed down to the spawned process;
+    when `track_output` is True, the returned protocol instance uses two
+    deferred queues that fire with the spawned process stdout and stderr
+    data.
 
     Returns the associated process protocol instance.
     """
 
-    process_proto = _TrackProcessProtocol(name)
+    process_proto = _TrackProcessProtocol(name, track_output=track_output)
     executable = cmd_args[0]
 
     # env=None, below, is relevant: it ensures that environment variables

--- a/player/process.py
+++ b/player/process.py
@@ -1,0 +1,109 @@
+# ----------------------------------------------------------------------------
+# vim: ts=4:sw=4:et
+# ----------------------------------------------------------------------------
+# player/process.py
+# ----------------------------------------------------------------------------
+
+"""
+Asyncrounous, Twisted Based, process management.
+"""
+
+from twisted.internet import defer, protocol
+from twisted import logger
+
+
+
+class _TrackProcessProtocol(protocol.ProcessProtocol):
+
+    """
+    Twisted ProcessProtocol used to track process startup, exit and output.
+
+    Exposes two relevant attributes:
+    - `started`: deferred that fires with PID when the process is started.
+    - `stopped`: deferred that fires with exit code when the process terminates.
+
+    If initialized with `track_output` to True, additionally exposes:
+    - `out_queue`: deferred queue that fires with process stdout data.
+    - `err_queue`: deferred queue that fires with process stderr data.
+    """
+
+    def __init__(self, name, track_output=False):
+
+        self.name = name
+        self.log = logger.Logger(namespace='player.proc.%s' % (name,))
+        self.started = defer.Deferred()
+        self.stopped = defer.Deferred()
+        self.out_queue = defer.DeferredQueue() if track_output else None
+        self.err_queue = defer.DeferredQueue() if track_output else None
+        self._track_output = track_output
+        self.pid = None
+
+
+    def connectionMade(self):
+
+        # Called by Twisted when the process is started.
+
+        self.pid = self.transport.pid
+        self.log.info('{n} process started, PID {p}', n=self.name, p=self.pid)
+        self.started.callback(self.pid)
+
+
+    def outReceived(self, data):
+
+        # Called by Twisted when the process writes to its standard output.
+
+        self.log.debug('{n} stdout: {d!r}', n=self.name, d=data)
+        if self._track_output:
+            self.out_queue.put(data)
+
+
+    def errReceived(self, data):
+
+        # Called by Twisted when the process writes to its standard error.
+
+        self.log.debug('{n} stderr: {d!r}', n=self.name, d=data)
+        if self._track_output:
+            self.err_queue.put(data)
+
+
+    def processEnded(self, reason):
+
+        # Called by Twisted when the process terminates.
+
+        exit_code = reason.value.exitCode
+        self.log.info('{n} process ended, exit code {ec}', n=self.name, ec=exit_code)
+        self.stopped.callback(exit_code)
+
+
+
+def spawn(reactor, cmd_args, name):
+
+    """
+    Simple wrapper around Twisted's IReactorProcess.spawnProcess.
+
+    Assumes the executable is the first entry in `cmd_args` and ensures
+    the current process environment is passed down to the spawned process.
+
+    Returns the associated process protocol instance.
+    """
+
+    process_proto = _TrackProcessProtocol(name)
+    executable = cmd_args[0]
+
+    # env=None, below, is relevant: it ensures that environment variables
+    # this process has set are passed down to the child process; in this
+    # case, PlayerManager probably set LD_LIBRARY_PATH, and DBusManager
+    # probably set DBUS_SESSION_BUS_ADDRESS.
+
+    _process_transport = reactor.spawnProcess(
+        process_proto,
+        executable,
+        cmd_args,
+        env=None,
+    )
+    return process_proto
+
+
+# ----------------------------------------------------------------------------
+# player/process.py
+# ----------------------------------------------------------------------------

--- a/settings-sample.json
+++ b/settings-sample.json
@@ -1,6 +1,6 @@
 {
     "environment": {
-        "dbus_run_session_bin": "/usr/bin/dbus-run-session",
+        "dbus_daemon_bin": "/usr/bin/dbus-daemon",
         "omxplayer_bin": "/usr/bin/omxplayer.bin",
         "ld_library_path": "/usr/lib/omxplayer"
     },


### PR DESCRIPTION
Notes:
* Fully addresses #37.
* Commit history may help better understand the changes, but here's a short rundown:
  * The tracking process protocol we were using to track `omxplayer.bin` processes has been factored out and slightly improved onto a new `player/process.py` module.
  * DBus manager uses that to spawn a private DBus daemon, grab the address and set the necessary DBUS_SESSION_BUS_ADDRESS environment variable.
  * The main `candle2017.py` no longer does the *odd* self-respawn.
  * Player manager now cleans up DBus manager on stopping, otherwise the spawned DBus daemon would be orphaned and keep running.

Benefits:
* Cleaner design and simpler control: all processes are our children (DBus daemon and omxplayers).
* Faster startup.
* Simpler system integration ensuring a clean stop.

Still handles unexpected process failures as before (unchanged in this PR):
* If our private DBus daemon goes away, player manager stops everything and `candle2017.py` exits.
* If any `omxplayer.bin` process goes away, player manager restarts it.
* The now simpler system integration `candle2017.service` file still ensures that if `candle2017.py` goes away, it is restarted.

In short, while not fully bullet proof (nothing ever is, is it?), we're pretty solid now.