### PR TITLE
More robust Web client UI.

### DIFF
--- a/webserver/web-root/index.html
+++ b/webserver/web-root/index.html
@@ -10,7 +10,7 @@
     html {
         padding: 0;
         margin: 0;
-        font-family: system-ui;
+        font-family: system-ui, sans-serif;
         height: 100vh;
     }
     body {
@@ -43,7 +43,7 @@
     select {
         margin: 0.2em 0.5em 0.2em 0.5em;
         display: block;
-        width: 8em;
+        width: 10em;
         font-size: 120%;
     }
     #left_pane {
@@ -69,7 +69,7 @@
     }
     #log_pane {
         width: 50%;
-        height: 100vh;
+        height: 92vh;
         float: left;
     }
     #log_scroller {
@@ -79,6 +79,7 @@
     }
     #log {
         font-family: monospace;
+	font-size: 90%;
         white-space: nowrap;
         overflow-x: auto;
         padding: 0.5em;
@@ -108,6 +109,7 @@
                     <button id="sll" onclick="set_log_level();"> SLL </button>
                     <div id="log_selects">
                         <select id="logger_namespace">
+                            <option value="">all loggers</option>
                             <option value="inputs">inputs</option>
                             <option value="inputs.network">inputs.network</option>
                             <option value="inputs.arduino">inputs.arduino</option>
@@ -115,13 +117,15 @@
                             <option value="inputs.arduino.proto">inputs.arduino.proto</option>
                             <option value="player">player</option>
                             <option value="player.dbus">player.dbus</option>
-                            <option value="player.mngr">player.mngr</option>
+                            <option value="player.mngr" selected="selected">player.mngr</option>
                             <option value="player.proc">player.proc</option>
                             <option value="player.each">player.each</option>
+                            <option value="webserver.http">player.http</option>
+                            <option value="webserver.ws">player.ws</option>
                         </select>
                         <select id="logger_level">
                             <option value="debug">debug</option>
-                            <option value="info">info</option>
+                            <option value="info" selected="selected">info</option>
                             <option value="warn">warn</option>
                             <option value="error">error</option>
                         </select>
@@ -132,7 +136,7 @@
     <div id="log_pane">
         <h1 onclick="mark_log();">
             log
-            <div class="note">click/tap to mark</div>
+            <div class="note">click/tap once to mark, twice to clear</div>
         </h1>
         <div id="log_scroller">
             <div id="log">

--- a/webserver/web-root/index.js
+++ b/webserver/web-root/index.js
@@ -102,6 +102,7 @@ function create_websocket() {
 
 function socket_open() {
     console.log('socket open');
+    update_log('-- CONNECTION UP --');
 }
 
 
@@ -131,7 +132,7 @@ function socket_message(msg) {
 function update_log(s) {
     log.innerText += s + "\n";
     log_count++;
-    if (log_count > 40) {
+    if ( log_count > 45 ) {
         pos = log.innerText.indexOf("\n"); 
         log.innerText = log.innerText.substring(pos+1);
     }
@@ -142,7 +143,21 @@ function update_log(s) {
 // Appends a marker line to the log.
 
 function mark_log() {
-    update_log('-- MARK --');
+    if ( log.innerText.endsWith('-- MARK --\n') ) {
+        clear_log();
+    } else {
+        update_log('-- MARK --');
+    }
+}
+
+
+
+// Clear log.
+
+function clear_log() {
+    log.innerText = "";
+    log_count = 0;
+    update_log('-- LOG CLEARED --');
 }
 
 
@@ -151,6 +166,7 @@ function mark_log() {
 
 function socket_close(e) {
     console.log('socket close');
+    update_log('-- CONNECTION LOST --');
 }
 
 
@@ -189,7 +205,6 @@ function set_log_level() {
         level: level
     }));
 }
-
 
 
 // ----------------------------------------------------------------------------

--- a/webserver/web-root/index.js
+++ b/webserver/web-root/index.js
@@ -167,6 +167,7 @@ function clear_log() {
 function socket_close(e) {
     console.log('socket close');
     update_log('-- CONNECTION LOST --');
+    socket = null;
 }
 
 
@@ -184,10 +185,10 @@ window.onload = function() {
 // level button click handler.
 
 function change_level(level) {
-    socket.send(JSON.stringify({
+    _socket_send({
         action: "change_level",
         level: level
-    }));
+    });
 }
 
 
@@ -199,11 +200,23 @@ function set_log_level() {
     var namespace = e.options[e.selectedIndex].value;
     e = document.getElementById("logger_level");
     var level = e.options[e.selectedIndex].value;
-    socket.send(JSON.stringify({
+    _socket_send({
         action: "set_log_level",
         namespace: namespace,
         level: level
-    }));
+    });
+}
+
+
+
+// Send an JSONified object over the websocket.
+
+function _socket_send(obj) {
+    if ( !socket ) {
+        update_log('-- NOT CONNECTED --');
+        return;
+    }
+    socket.send(JSON.stringify(obj));
 }
 
 


### PR DESCRIPTION
Highlights:
* Minor adjustments to component sizes, including slightly smaller log pane font size.
* *Set log level* control changes:
  * Added "all loggers" option: useful and effortless.
  * Default selectors now set to `player.mngr` and `info`: seems useful from the all `warn` default.
* Clicking/tapping a second time in the *log* heading, clears the log.
* Increased the number of log lines to 45 (matching the vertical space on my iPad) (enough for #42? maybe not, we'll see).
* Single client connection:
  * Now enforced server side: before, logs/plots would be sent to latest client, but older clients could still control... Server now drops the connection to older clients.
  * Client logs messages on connection up/down.
  * Client logs messages if trying to control but disconnected.