### PR TITLE
Simpler, high level "wiring".

### DIFF
--- a/candle2017.py
+++ b/candle2017.py
@@ -21,6 +21,7 @@ import inputs
 import webserver
 
 
+
 def load_settings(filename='settings.json'):
 
     """
@@ -67,32 +68,49 @@ def start_things(reactor, settings):
     # Setup the logging system.
     log_level = settings.get('loglevel', 'warn')
     log_levels = settings.get('loglevels', {})
-    log.setup(level=log_level, namespace_levels=log_levels,
-              extra_observer=log_bridge)
+    log.setup(level=log_level, namespace_levels=log_levels, extra_observer=log_bridge)
+
+    # Will be used to dynamically set logging levels.
+    set_level_callable = log.set_level
+
 
     # Create the player manager.
     player_manager = player.PlayerManager(reactor, settings)
 
+    # Will be used to request the player manager to trigger a level change.
+    change_play_level_callable = player_manager.level
+
+
     # Start the HTTP and websocket servers.
-    # `raw_listener` to be used to push raw data and logs to connected websockets.
     webserver.setup_webserver(reactor)
-    raw_listener = webserver.setup_websocket(
+    ws_factory = webserver.setup_websocket(
         reactor,
-        player_manager.level,
-        log.set_level,
+        change_play_level_callable,
+        set_level_callable,
     )
 
-    # Create the input manager, wiring it to the player manager and `raw_listener`.
+    # Will be used to push data to the connected web client.
+    push_raw_to_websocket_callable = ws_factory.raw
+    push_log_to_websocket_callable = ws_factory.log_message
+
+
+    # Create the input manager, wiring it to the appropriate callables.
     # TODO: `_input_manager` not used, can go away.
     _input_manager = inputs.InputManager(
-        reactor, player_manager, raw_listener, settings
+        reactor,
+        change_play_level_callable,
+        push_raw_to_websocket_callable,
+        settings,
     )
 
-    # Connect the log bridge to the raw listener.
-    log_bridge.destination_callable = raw_listener.log_message
+
+    # Connect the log bridge to the websocket client.
+    log_bridge.destination_callable = push_log_to_websocket_callable
+
 
     # Ensure a clean stop.
     reactor.addSystemEventTrigger('before', 'shutdown', stop_things, player_manager)
+
 
     # Start the player manager.
     try:

--- a/candle2017.py
+++ b/candle2017.py
@@ -70,14 +70,14 @@ def start_things(reactor, settings):
     log_levels = settings.get('loglevels', {})
     log.setup(level=log_level, namespace_levels=log_levels, extra_observer=log_bridge)
 
-    # Will be used to dynamically set logging levels.
-    set_level_callable = log.set_level
+    # Passed to components that need to dynamically set logging levels.
+    set_log_levels_callable = log.set_level
 
 
     # Create the player manager.
     player_manager = player.PlayerManager(reactor, settings)
 
-    # Will be used to request the player manager to trigger a level change.
+    # Passed to components that need to trigger player level changes.
     change_play_level_callable = player_manager.level
 
 
@@ -86,16 +86,16 @@ def start_things(reactor, settings):
     ws_factory = webserver.setup_websocket(
         reactor,
         change_play_level_callable,
-        set_level_callable,
+        set_log_levels_callable,
     )
 
-    # Will be used to push data to the connected web client.
+    # Passed to components that need to push data to the connected web client.
     push_raw_to_websocket_callable = ws_factory.raw
     push_log_to_websocket_callable = ws_factory.log_message
 
 
     # Create the input manager, wiring it to the appropriate callables.
-    # TODO: `_input_manager` not used, can go away.
+    # TODO: `_input_manager` either goes away or is used on exit/cleanup.
     _input_manager = inputs.InputManager(
         reactor,
         change_play_level_callable,
@@ -149,7 +149,6 @@ def main():
     settings = load_settings()
     task.react(start_things, (settings,))
 
-    return 0
 
 
 if __name__ == '__main__':

--- a/inputs/arduino/__init__.py
+++ b/inputs/arduino/__init__.py
@@ -11,13 +11,13 @@ The serial based Arduino input.
 from .input import ArduinoInput
 
 
-def initialize(input_manager, reactor, **kwargs):
+def initialize(*args, **kwargs):
 
     """
     Initializes the Arduino input.
     """
 
-    return ArduinoInput(input_manager, reactor, **kwargs)
+    return ArduinoInput(*args, **kwargs)
 
 
 # ----------------------------------------------------------------------------

--- a/inputs/arduino/serial.py
+++ b/inputs/arduino/serial.py
@@ -51,7 +51,12 @@ class _ArduinoProtocol(basic.LineReceiver):
 
         self._log.debug('data received: {d!r}', d=line)
         try:
-            pdu = self._decode_pdu_buffer(line)
+            pdu = int.from_bytes(line, byteorder='little')
+        except (TypeError, ValueError):
+            self._log.warn('bad value: {d!r}', d=line)
+            return
+
+        try:
             self._pdu_received_callable(pdu)
         except Exception as e:
             self._log.warn('callable exception: {e!s}', e=e)
@@ -65,14 +70,6 @@ class _ArduinoProtocol(basic.LineReceiver):
         # the parent class does not implement it.
 
         self._log.warn('unexpected data: {d!r}', d=data)
-
-
-    @staticmethod
-    def _decode_pdu_buffer(pdu_buffer):
-
-        # TODO: Throw this method away and inline it in `lineReceived`?
-
-        return int.from_bytes(pdu_buffer, byteorder='little')
 
 
     def connectionLost(self, reason=protocol.connectionDone):

--- a/inputs/input_manager.py
+++ b/inputs/input_manager.py
@@ -19,22 +19,19 @@ class InputManager(object):
     Initializes inputs and mediates their feeds to a player manager.
     """
 
-    def __init__(self, reactor, player_manager, raw_listener, settings):
+    def __init__(self, reactor, change_level_callable, raw_callable, settings):
 
         """
         Initializes configured inputs:
         - `reactor` is the Twisted reactor.
-        - `player_manager` should have `level` method to trigger level changes.
-        - `raw_listener` should a `raw` method to trigger raw input data handling.
+        - `change_level_callable` should trigger level changes when called.
+        - `raw_callable` will be called by inputs with (source, value) raw data.
         - `settings` is a dict containing the 'inputs' key.
         """
 
-        # TODO: Maybe `player_manager` and `raw_listener` could be replaced with
-        # callables instead of objects with a given interface.
-
         self._reactor = reactor
-        self._player_mgr = player_manager
-        self._raw_listener = raw_listener
+        self._change_level_callable = change_level_callable
+        self._raw_callable = raw_callable
         self._settings = settings
 
         self._inputs = []
@@ -72,19 +69,19 @@ class InputManager(object):
     def level(self, level, comment):
 
         """
-        Inputs will call this, which will be forwarded to the player manager.
+        Inputs will call this, to signal play level changes.
         """
 
-        self._player_mgr.level(level, comment)
+        self._change_level_callable(level, comment)
 
 
     def raw(self, source, value):
 
         """
-        Inputs will call this, which will be forwarded to the raw listener.
+        Inputs will call this, to signal their raw data.
         """
 
-        self._raw_listener.raw(source, value)
+        self._raw_callable(source, value)
 
 
 # ----------------------------------------------------------------------------

--- a/inputs/input_manager.py
+++ b/inputs/input_manager.py
@@ -32,7 +32,6 @@ class InputManager(object):
         self._reactor = reactor
         self._change_level_callable = change_level_callable
         self._raw_callable = raw_callable
-        self._settings = settings
 
         self._inputs = []
         self._create_inputs(settings)
@@ -56,32 +55,26 @@ class InputManager(object):
                 raise ValueError('invalid %r setting: %s' % (input_type, e))
 
 
-    def _create_input_network(self, port):
+    def _create_input_network(self, port, interface='0.0.0.0'):
 
-        network.initialize(self, self._reactor, port)
-
-
-    def _create_input_arduino(self, **kwargs):
-
-        arduino.initialize(self, self._reactor, **kwargs)
-
-
-    def level(self, level, comment):
-
-        """
-        Inputs will call this, to signal play level changes.
-        """
-
-        self._change_level_callable(level, comment)
+        network.initialize(
+            self._reactor,
+            port,
+            interface,
+            self._change_level_callable,
+        )
 
 
-    def raw(self, source, value):
+    def _create_input_arduino(self, device_file, baud_rate, thresholds):
 
-        """
-        Inputs will call this, to signal their raw data.
-        """
-
-        self._raw_callable(source, value)
+        arduino.initialize(
+            self._reactor,
+            device_file,
+            baud_rate,
+            thresholds,
+            self._change_level_callable,
+            self._raw_callable,
+        )
 
 
 # ----------------------------------------------------------------------------

--- a/inputs/network/__init__.py
+++ b/inputs/network/__init__.py
@@ -11,13 +11,13 @@ The TCP network connection input.
 from .protocol import ControlFactory
 
 
-def initialize(input_manager, reactor, port, interface='0.0.0.0'):
+def initialize(reactor, port, interface, change_level_callable):
 
     """
     Initializes the TCP input and starts listening for connections.
     """
 
-    factory = ControlFactory(input_manager)
+    factory = ControlFactory(change_level_callable)
     reactor.listenTCP(port, factory, interface=interface)
 
 

--- a/inputs/network/protocol.py
+++ b/inputs/network/protocol.py
@@ -44,7 +44,7 @@ class ControlProtocol(basic.LineReceiver):
         except Exception:
             _log.warn('ignored {l!r}', l=line)
         else:
-            self.factory.input_manager.level(level, 'network')
+            self.factory.change_level_callable(level, 'network')
 
 
     def rawDataReceived(self, data):
@@ -73,12 +73,12 @@ class ControlFactory(protocol.Factory):
 
     protocol = ControlProtocol
 
-    def __init__(self, input_manager):
+    def __init__(self, change_level_callable):
 
         # Need to keep track of the input manager such that protocol instances
         # can notify it about level change requests.
 
-        self.input_manager = input_manager
+        self.change_level_callable = change_level_callable
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Key changes:
* All cross-component wiring now consistently based on functions/callables: no more callables in some places vs. objects methods in others (in particular, I hated the `raw_listener` name, which was already *more* than a raw listener).
* More readable main code "wiring" with easier to understand names and comments.
* Simpler Arduino serial data handling: inlined PDU decoding to where the payload format comment is: it is so simple there is no need to have a separate method. It is also now more robust, wrapped in a try/except block.

The alternative to this simpler, callable-based, wiring is creating a "common event/request/notification dispatcher" object and using it all around. Happy to consider such approach if you prefer.