### PR TITLE
Fix handling of websocket some web socket messages.

### DIFF
--- a/webserver/websocket.py
+++ b/webserver/websocket.py
@@ -58,11 +58,12 @@ class WSProto(websocket.WebSocketServerProtocol):
             _log.warn('invalid payload ignored: {p!r}', p=payload)
         else:
             method_name = '_action_%s' % message.get('action', 'invalid')
-            method = getattr(self, method_name)
+            method = getattr(self, method_name, self._action_invalid)
             method(message)
 
 
-    def _action_invalid(self, message):
+    @staticmethod
+    def _action_invalid(message):
 
         _log.warn('invalid message: {m!r}', m=message)
 


### PR DESCRIPTION
In particular, addresses messages with the `action` attribute but with an unsupported action value.

Example:
* Say the `action` attribute is `hello there`.
* `getattr` would fail to find an attribute (method!) named `_action_hello there` and would raise an exception.
* Not awful and everything would keep running, but why mess up the logs with such stack traces? :)