### PR TITLE
Minor DBus tracking fix.

### DIFF
--- a/player/dbus_manager.py
+++ b/player/dbus_manager.py
@@ -198,9 +198,10 @@ class DBusManager(object):
             return
 
         try:
-            d.callback(None)
-        except defer.AlreadyCalledError:
-            self.log.error('failed firing {n!r} deferred', n=name)
+            if not d.called:
+                d.callback(None)
+        except Exception as e:
+            self.log.error('failed firing {n!r} deferred: {e!r}', n=name, e=e)
 
 
     def track_dbus_name(self, name):


### PR DESCRIPTION
DBus manager tracks names as they show up/go away from our private DBus.

It was double-triggering the deferreds that we use in that:
* I did not dig fully to understand how/why.
* I just prevented double-triggering them to avoid unnecessary (but not important) error logs on some exiting scenarios.
