### PR TITLE
Major redesign: new event manager decouples callers from callees.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Development Notes
 
 Lint with:
 ```
-$ pylint candle2017 inputs/ player/ webserver/ log/
+$ pylint candle2017 events/ inputs/ player/ webserver/ log/
 ```
 
 

--- a/candle2017.py
+++ b/candle2017.py
@@ -66,7 +66,7 @@ def start_things(reactor, settings):
     # Decouples callers from callees, who subscribe to events fired by callers.
     event_manager = events.EventManager()
 
-    # Twisted logger observer: fires 'log-message' events.
+    # Twisted logger observer: fires `log_message` events.
     log_bridge = log.LogBridge(event_manager)
 
     # Setup the logging system.
@@ -75,7 +75,7 @@ def start_things(reactor, settings):
     log.setup(level=log_level, namespace_levels=log_levels, extra_observer=log_bridge)
 
     # Tell the event manager what to do with 'set-log-level' events.
-    event_manager.subscribe('set-log-level', log.set_level)
+    event_manager.subscribe(event_manager.set_log_level, log.set_level)
 
 
     # Create the player manager.

--- a/candle2017.py
+++ b/candle2017.py
@@ -15,6 +15,7 @@ import sys
 
 from twisted.internet import task, defer
 
+import events
 import player
 import log
 import inputs
@@ -62,50 +63,33 @@ def start_things(reactor, settings):
     Exits when the player manager terminates.
     """
 
-    # Twisted logger observer, will forward log messages to websockets.
-    log_bridge = log.LogBridge()
+    # Decouples callers from callees, who subscribe to events fired by callers.
+    event_manager = events.EventManager()
+
+    # Twisted logger observer: fires 'log-message' events.
+    log_bridge = log.LogBridge(event_manager)
 
     # Setup the logging system.
     log_level = settings.get('loglevel', 'warn')
     log_levels = settings.get('loglevels', {})
     log.setup(level=log_level, namespace_levels=log_levels, extra_observer=log_bridge)
 
-    # Passed to components that need to dynamically set logging levels.
-    set_log_levels_callable = log.set_level
+    # Tell the event manager what to do with 'set-log-level' events.
+    event_manager.subscribe('set-log-level', log.set_level)
 
 
     # Create the player manager.
-    player_manager = player.PlayerManager(reactor, settings)
-
-    # Passed to components that need to trigger player level changes.
-    change_play_level_callable = player_manager.level
+    player_manager = player.PlayerManager(reactor, event_manager, settings)
 
 
     # Start the HTTP and websocket servers.
     webserver.setup_webserver(reactor)
-    ws_factory = webserver.setup_websocket(
-        reactor,
-        change_play_level_callable,
-        set_log_levels_callable,
-    )
-
-    # Passed to components that need to push data to the connected web client.
-    push_raw_to_websocket_callable = ws_factory.raw
-    push_log_to_websocket_callable = ws_factory.log_message
+    webserver.setup_websocket(reactor, event_manager)
 
 
-    # Create the input manager, wiring it to the appropriate callables.
+    # Create the input manager.
     # TODO: `_input_manager` either goes away or is used on exit/cleanup.
-    _input_manager = inputs.InputManager(
-        reactor,
-        change_play_level_callable,
-        push_raw_to_websocket_callable,
-        settings,
-    )
-
-
-    # Connect the log bridge to the websocket client.
-    log_bridge.destination_callable = push_log_to_websocket_callable
+    _input_manager = inputs.InputManager(reactor, event_manager, settings)
 
 
     # Ensure a clean stop.

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -1,26 +1,16 @@
 # ----------------------------------------------------------------------------
 # vim: ts=4:sw=4:et
 # ----------------------------------------------------------------------------
-# inputs/network/__init__.py
+# events/__init__.py
 # ----------------------------------------------------------------------------
 
 """
-The TCP network connection input.
+Holds all event tracking code.
 """
 
-from .protocol import ControlFactory
-
-
-def initialize(reactor, port, interface, event_manager):
-
-    """
-    Initializes the TCP input and starts listening for connections.
-    """
-
-    factory = ControlFactory(event_manager)
-    reactor.listenTCP(port, factory, interface=interface)
+from .event_manager import EventManager
 
 
 # ----------------------------------------------------------------------------
-# inputs/network/__init__.py
+# events/__init__.py
 # ----------------------------------------------------------------------------

--- a/events/event_manager.py
+++ b/events/event_manager.py
@@ -23,6 +23,7 @@ class EventManager(object):
 
         self._log = logger.Logger(namespace=name)
         self._subscriptions = collections.defaultdict(list)
+        self._functions = {}
 
 
     def _event_functions(self, event):
@@ -44,7 +45,7 @@ class EventManager(object):
             pass
 
 
-    def fire(self, event, *args, log_failures=True, **kwargs):
+    def _fire(self, event, *args, log_failures=True, **kwargs):
 
         functions = self._event_functions(event)
         if not functions:
@@ -59,6 +60,21 @@ class EventManager(object):
                     self._log.error(msg)
                 else:
                     sys.stderr.write(msg+'\n')
+
+
+    def __getattr__(self, name):
+
+        function = self._functions.get(name)
+        if function:
+            return function
+
+        def function(*args, **kwargs):
+            this_function = self._functions[name]
+            self._fire(this_function, *args, **kwargs)
+
+        self._functions[name] = function
+
+        return function
 
 
 # ----------------------------------------------------------------------------

--- a/events/event_manager.py
+++ b/events/event_manager.py
@@ -1,0 +1,66 @@
+# ----------------------------------------------------------------------------
+# vim: ts=4:sw=4:et
+# ----------------------------------------------------------------------------
+# event/event_manager.py
+# ----------------------------------------------------------------------------
+
+"""
+Simple callable based event manager.
+"""
+
+from __future__ import absolute_import
+
+import collections
+import sys
+
+from twisted import logger
+
+
+
+class EventManager(object):
+
+    def __init__(self, name='events.mngr'):
+
+        self._log = logger.Logger(namespace=name)
+        self._subscriptions = collections.defaultdict(list)
+
+
+    def _event_functions(self, event):
+
+        return self._subscriptions.get(event)
+
+
+    def subscribe(self, event, function):
+
+        self._subscriptions[event].append(function)
+
+
+    def unsubscribe(self, event, function):
+
+        functions = self._event_functions(event)
+        try:
+            functions.remove(function)
+        except ValueError:
+            pass
+
+
+    def fire(self, event, *args, log_failures=True, **kwargs):
+
+        functions = self._event_functions(event)
+        if not functions:
+            return
+
+        for function in functions:
+            try:
+                function(*args, **kwargs)
+            except Exception as e:
+                msg = 'firing {ev!r} failed: {e}'.format(ev=event, e=e)
+                if log_failures:
+                    self._log.error(msg)
+                else:
+                    sys.stderr.write(msg+'\n')
+
+
+# ----------------------------------------------------------------------------
+# event/event_manager.py
+# ----------------------------------------------------------------------------

--- a/inputs/arduino/input.py
+++ b/inputs/arduino/input.py
@@ -29,7 +29,7 @@ class ArduinoInput(object):
 
     Keeps track of the last _INPUT_SIZE PDUs and calculates an aggregated
     derivative which is compared is compared to the given `thresholds` and,
-    in turn, to fire 'change-level' events via the `event_manager`.
+    in turn, to fire `change_play_level` events via the `event_manager`.
     """
 
     def __init__(self, reactor, device_file, baud_rate, thresholds, event_manager):
@@ -53,7 +53,7 @@ class ArduinoInput(object):
         _log.debug('aggregated derivative: {ad!r}', ad=agg_d)
 
         # Notify about the "raw data" we just received.
-        self._event_manager.fire('arduino-raw', raw=pdu, agd=agg_d)
+        self._event_manager.arduino_raw_data(raw=pdu, agd=agg_d)
 
         # Find if the aggregated derivative is over any of the thresholds and
         # request a level change, if that is the case.
@@ -63,7 +63,7 @@ class ArduinoInput(object):
                 play_level = level
         if play_level != self._last_play_level:
             self._last_play_level = play_level
-            self._event_manager.fire('change-level', play_level, "arduino %r" % (agg_d,))
+            self._event_manager.change_play_level(play_level, "arduino %r" % (agg_d,))
 
 
     @staticmethod

--- a/inputs/input_manager.py
+++ b/inputs/input_manager.py
@@ -19,19 +19,17 @@ class InputManager(object):
     Initializes inputs and mediates their feeds to a player manager.
     """
 
-    def __init__(self, reactor, change_level_callable, raw_callable, settings):
+    def __init__(self, reactor, event_manager, settings):
 
         """
         Initializes configured inputs:
         - `reactor` is the Twisted reactor.
-        - `change_level_callable` should trigger level changes when called.
-        - `raw_callable` will be called by inputs with (source, value) raw data.
+        - `event_manager` # TODO: update this
         - `settings` is a dict containing the 'inputs' key.
         """
 
         self._reactor = reactor
-        self._change_level_callable = change_level_callable
-        self._raw_callable = raw_callable
+        self._event_manager = event_manager
 
         self._inputs = []
         self._create_inputs(settings)
@@ -61,7 +59,7 @@ class InputManager(object):
             self._reactor,
             port,
             interface,
-            self._change_level_callable,
+            self._event_manager,
         )
 
 
@@ -72,8 +70,7 @@ class InputManager(object):
             device_file,
             baud_rate,
             thresholds,
-            self._change_level_callable,
-            self._raw_callable,
+            self._event_manager,
         )
 
 

--- a/inputs/network/protocol.py
+++ b/inputs/network/protocol.py
@@ -44,7 +44,7 @@ class ControlProtocol(basic.LineReceiver):
         except Exception:
             _log.warn('ignored {l!r}', l=line)
         else:
-            self.factory.event_manager.fire('change-level', level, 'network')
+            self.factory.event_manager.change_play_level(level, 'network')
 
 
     def rawDataReceived(self, data):
@@ -75,7 +75,7 @@ class ControlFactory(protocol.Factory):
 
     def __init__(self, event_manager):
 
-        # The event manager is used to fire 'change-level' events.
+        # The event manager is used to fire `change_play_level` events.
 
         self.event_manager = event_manager
 

--- a/inputs/network/protocol.py
+++ b/inputs/network/protocol.py
@@ -44,7 +44,7 @@ class ControlProtocol(basic.LineReceiver):
         except Exception:
             _log.warn('ignored {l!r}', l=line)
         else:
-            self.factory.change_level_callable(level, 'network')
+            self.factory.event_manager.fire('change-level', level, 'network')
 
 
     def rawDataReceived(self, data):
@@ -73,12 +73,11 @@ class ControlFactory(protocol.Factory):
 
     protocol = ControlProtocol
 
-    def __init__(self, change_level_callable):
+    def __init__(self, event_manager):
 
-        # Need to keep track of the input manager such that protocol instances
-        # can notify it about level change requests.
+        # The event manager is used to fire 'change-level' events.
 
-        self.change_level_callable = change_level_callable
+        self.event_manager = event_manager
 
 
 # ----------------------------------------------------------------------------

--- a/log/bridge.py
+++ b/log/bridge.py
@@ -19,12 +19,12 @@ from twisted import logger
 class LogBridge(object):
 
     """
-    Twisted logger observer firing 'log-message' events for each emitted log.
+    Twisted logger observer firing `log_message` events for each emitted log.
     """
 
     def __init__(self, event_manager=None):
 
-        # Used to fire 'log-message' events.
+        # Used to fire `log_message` events.
         self._event_manager = event_manager
 
 
@@ -50,7 +50,7 @@ class LogBridge(object):
                 event.get('log_namespace', '-'),
                 logger.formatEvent(event),
             )
-            self._event_manager.fire('log-message', msg, log_failures=False)
+            self._event_manager.log_message(msg, log_failures=False)
 
 
 # ----------------------------------------------------------------------------

--- a/log/bridge.py
+++ b/log/bridge.py
@@ -19,14 +19,13 @@ from twisted import logger
 class LogBridge(object):
 
     """
-    Twisted logger observer that forwards emitted logs to a callable, accepting
-    a string as its single argument.
+    Twisted logger observer firing 'log-message' events for each emitted log.
     """
 
-    def __init__(self, destination_callable=None):
+    def __init__(self, event_manager=None):
 
-        # Where we'll forward log messages to.
-        self.destination_callable = destination_callable
+        # Used to fire 'log-message' events.
+        self._event_manager = event_manager
 
 
     def __call__(self, event):
@@ -35,7 +34,8 @@ class LogBridge(object):
         # Details about `event` and more at:
         # http://twistedmatrix.com/documents/current/core/howto/logger.html
 
-        if self.destination_callable:
+        # TODO: Maybe we don't need this any longer: remove condition?
+        if self._event_manager:
 
             # Formatted messages contain four elements, space separated:
             # - Fixed width, capitalized first letter of log level.
@@ -50,7 +50,7 @@ class LogBridge(object):
                 event.get('log_namespace', '-'),
                 logger.formatEvent(event),
             )
-            self.destination_callable(msg)
+            self._event_manager.fire('log-message', msg, log_failures=False)
 
 
 # ----------------------------------------------------------------------------

--- a/player/player_manager.py
+++ b/player/player_manager.py
@@ -36,10 +36,11 @@ class PlayerManager(object):
     #   - Track player completion / process exit.
     #   - Respawn a new level X player.
 
-    def __init__(self, reactor, settings):
+    def __init__(self, reactor, event_manager, settings):
         """
         Initializes the player manager:
         - `reactor` is the Twisted reactor.
+        - `event_manager` is used to subscribe to 'change-level' events.
         - `settings` is a dict with:
            - ['environment']['ld_library_path']
            - ['environment']['omxplayer_bin']
@@ -51,6 +52,9 @@ class PlayerManager(object):
 
         self.reactor = reactor
         self.settings = settings
+
+        # TODO: Review where/when to call this.
+        event_manager.subscribe('change-level', self._change_play_level)
 
         # part of our public interface, OMXPlayer will use this
         self.dbus_mgr = DBusManager(reactor, settings)
@@ -173,7 +177,7 @@ class PlayerManager(object):
         yield player.spawn(end_callable=lambda exit_code: self._player_ended(level))
 
 
-    def level(self, new_level, comment=''):
+    def _change_play_level(self, new_level, comment=''):
         """
         Triggers video playing level change.
         Does nothing if:

--- a/player/player_manager.py
+++ b/player/player_manager.py
@@ -40,7 +40,7 @@ class PlayerManager(object):
         """
         Initializes the player manager:
         - `reactor` is the Twisted reactor.
-        - `event_manager` is used to subscribe to 'change-level' events.
+        - `event_manager` is used to subscribe to `change_play_level` events.
         - `settings` is a dict with:
            - ['environment']['ld_library_path']
            - ['environment']['omxplayer_bin']
@@ -54,7 +54,7 @@ class PlayerManager(object):
         self.settings = settings
 
         # TODO: Review where/when to call this.
-        event_manager.subscribe('change-level', self._change_play_level)
+        event_manager.subscribe(event_manager.change_play_level, self._change_play_level)
 
         # part of our public interface, OMXPlayer will use this
         self.dbus_mgr = DBusManager(reactor, settings)

--- a/settings-sample.json
+++ b/settings-sample.json
@@ -7,6 +7,7 @@
     "loglevel": "warn",
     "loglevels": {
         "txdbus": "warn",
+        "events.mngr": "warn",
         "player": "warn",
         "player.dbus": "warn",
         "player.mngr": "warn",

--- a/webserver/websocket.py
+++ b/webserver/websocket.py
@@ -75,7 +75,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         except KeyError:
             _log.warn('missing level: {m!r}', m=message)
         else:
-            self.factory.change_level_callable(level, comment='web')
+            self.factory.event_manager.fire('change-level', level, comment='web')
 
 
     def _action_set_log_level(self, message):
@@ -86,7 +86,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         except KeyError:
             _log.warn('missing level/namespace: {m!r}', m=message)
         else:
-            self.factory.set_log_level_callable(namespace, level)
+            self.factory.event_manager.fire('set-log-level', namespace, level)
             # Log message on the specified logger/level to feed user back.
             log = logger.Logger(namespace=namespace)
             method = getattr(log, level)
@@ -110,7 +110,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         self.sendMessage(msg, isBinary=False)
 
 
-    def raw(self, **values):
+    def push_raw_data(self, **values):
 
         """
         Called by our factory to send raw data to the client.
@@ -123,7 +123,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         self._send_message_dict('chart-data', values)
 
 
-    def log_message(self, text):
+    def push_log_message(self, text):
 
         """
         Called by our factory to send log messages to the client.
@@ -146,15 +146,16 @@ class WSFactory(websocket.WebSocketServerFactory):
 
     protocol = WSProto
 
-    def __init__(self, change_level_callable, set_log_level_callable,
-                 *args, **kwargs):
+    def __init__(self, event_manager, *args, **kwargs):
 
         # Track a single `_connected_protocol` so that we can push data.
 
         super(WSFactory, self).__init__(*args, **kwargs)
         self._connected_protocol = None
-        self.change_level_callable = change_level_callable
-        self.set_log_level_callable = set_log_level_callable
+        self.event_manager = event_manager
+
+        event_manager.subscribe('arduino-raw', self._push_raw_data_to_client)
+        event_manager.subscribe('log-message', self._push_log_msg_to_client)
 
 
     def set_active_protocol(self, active_proto):
@@ -181,40 +182,38 @@ class WSFactory(websocket.WebSocketServerFactory):
         self._connected_protocol = None
 
 
-    def raw(self, **values):
+    def _push_raw_data_to_client(self, **values):
 
         """
         Sends raw `values` to the connected protocol, if any.
         """
 
         if self._connected_protocol:
-            self._connected_protocol.raw(**values)
+            self._connected_protocol.push_raw_data(**values)
 
 
-    def log_message(self, message):
+    def _push_log_msg_to_client(self, message):
 
         """
         Sends the log `message` to the connected protocol, if any.
         """
 
         if self._connected_protocol:
-            self._connected_protocol.log_message(message)
+            self._connected_protocol.push_log_message(message)
 
 
 
-def setup_websocket(reactor, change_level_callable, set_log_level_callable):
+def setup_websocket(reactor, event_manager):
 
     """
     Starts listening for websocket connections.
     """
 
-    factory = WSFactory(change_level_callable, set_log_level_callable)
+    factory = WSFactory(event_manager)
 
     # TODO: Should port/interface be configurable? Client may need adjustments.
     reactor.listenTCP(8081, factory, interface='0.0.0.0')
     _log.info('listening for WSCK connections on 0.0.0.0:8081')
-
-    return factory
 
 
 # ----------------------------------------------------------------------------

--- a/webserver/websocket.py
+++ b/webserver/websocket.py
@@ -75,7 +75,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         except KeyError:
             _log.warn('missing level: {m!r}', m=message)
         else:
-            self.factory.event_manager.fire('change-level', level, comment='web')
+            self.factory.event_manager.change_play_level(level, comment='web')
 
 
     def _action_set_log_level(self, message):
@@ -86,7 +86,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         except KeyError:
             _log.warn('missing level/namespace: {m!r}', m=message)
         else:
-            self.factory.event_manager.fire('set-log-level', namespace, level)
+            self.factory.event_manager.set_log_level(namespace, level)
             # Log message on the specified logger/level to feed user back.
             log = logger.Logger(namespace=namespace)
             method = getattr(log, level)
@@ -154,8 +154,8 @@ class WSFactory(websocket.WebSocketServerFactory):
         self._connected_protocol = None
         self.event_manager = event_manager
 
-        event_manager.subscribe('arduino-raw', self._push_raw_data_to_client)
-        event_manager.subscribe('log-message', self._push_log_msg_to_client)
+        event_manager.subscribe(event_manager.arduino_raw_data, self._push_raw_data_to_client)
+        event_manager.subscribe(event_manager.log_message, self._push_log_msg_to_client)
 
 
     def set_active_protocol(self, active_proto):


### PR DESCRIPTION
Like I commented in #50's linked video, wiring things together started to become complex (and *Simple is better than complex*, from the Zen of Python).

Completing #27 and #28 implies some kind of "mutual dependency" between the arduino sensor input and the websocket server, which would be difficult to read and maintain if we keep a plain take-this-callable-and-use-it approach.

This PR implements a very simple event manager:
* Events are fired and subscribed to.
* Event subscriptions take two arguments:
  * An object identifying the event.
  * A callabe that will be called when the event fires.
* Firing events take one or more arguments:
  * An object identifying the event.
  * Optional positional and/or named arguments that will be passed to the subscribed callables.

From there, most of the changes are pretty small and trivial, but a bit spread out across the code.

Final notes:
* For simplicity, I decided to use strings as events (not necessarily good/scalable/easy to verify).
* The `fire` event manager method takes a `log_failures` named argument which defaults to `True` but needs to be set to `False` when firing events related to logging (otherwise, their processing would trigger logging which would trigger an event which would trigger logging, ad infinitum -- or until the call stack fills up)
* An interesting improvement would allow us to do as follows, all without having the event manager initially know about any specific events/methods:

```
event_manager = EventManager()

# subscribe to an event called "some_method"
event_manager.subscribe(event_manager.some_method, <some-callable>)

# fire the "some_method" event
event_manager.some_method(<arguments>)
```

May need some "dynamic tricks", but leads to much more readable and natural code. ;-)