### PR TITLE
Event manager: Cleaner, more natural and readable API.

### DIFF
--- a/candle2017.py
+++ b/candle2017.py
@@ -63,7 +63,7 @@ def start_things(reactor, settings):
     Exits when the player manager terminates.
     """
 
-    # Decouples callers from callees, who subscribe to events fired by callers.
+    # Decouples callers from callees, who "subscribe" to events "fired" by callers.
     event_manager = events.EventManager()
 
     # Twisted logger observer: fires `log_message` events.
@@ -74,8 +74,8 @@ def start_things(reactor, settings):
     log_levels = settings.get('loglevels', {})
     log.setup(level=log_level, namespace_levels=log_levels, extra_observer=log_bridge)
 
-    # Tell the event manager what to do with 'set-log-level' events.
-    event_manager.subscribe(event_manager.set_log_level, log.set_level)
+    # Tell the event manager what to do with `set_log_level` events.
+    event_manager.set_log_level.calls(log.set_level)
 
 
     # Create the player manager.

--- a/events/event.py
+++ b/events/event.py
@@ -32,6 +32,9 @@ class Event(object):
         self._name = name
         self._log = logger.Logger(namespace='events.%s' % (name,))
 
+        # See `_log_handler_failure` below.
+        self.use_log = True
+
         # Handler functions/callables.
         self._functions = []
 
@@ -48,14 +51,9 @@ class Event(object):
     # There could be a "does_not_call" method to remove a known handler.
 
 
-    def __call__(self, *args, log_failures=True, **kwargs):
+    def __call__(self, *args, **kwargs):
 
         # Fires the event by calling all handler functions.
-
-        # `log_failures` is used to prevent usage of the logging system:
-        # This is necessary when a logging handler fires events (otherwise,
-        # any exception here would trigger a log messages, that would trigger
-        # an event, that would trigger a log messages, ad infinitum).
 
         for function in self._functions:
             try:
@@ -63,25 +61,48 @@ class Event(object):
             except Exception as e:
                 # Catching exceptions here is critical to ensure decoupling
                 # callables (firing events) from callees (handling events).
+                self._log_handler_failure(function, e)
 
-                # Try to produce a useful message including:
-                # - The event name.
-                # - The callable name.
-                # - The raised execption.
 
-                callable_name = getattr(function, '__qualname__', None)
-                if callable_name is None:
-                    callable_name = getattr(function, '__name__', 'non-named callable')
+    def _log_handler_failure(self, function, e):
 
-                msg = 'firing {ev!r} with {cn!r} failed: {e!r}'.format(
-                    ev=self._name,
-                    cn=callable_name,
-                    e=e,
-                )
-                if log_failures:
-                    self._log.error(msg)
-                else:
-                    sys.stderr.write(msg+'\n')
+        # Try to produce a useful message including:
+        # - The event name.
+        # - The callable name.
+        # - The raised execption.
+
+        # `self.use_log` is used to prevent usage of the logging system:
+        # This is necessary when a logging handler fires events (otherwise,
+        # any exception here would trigger a log messages, that would trigger
+        # an event, that would trigger a log messages, ad infinitum).
+        #
+        # Possible values:
+        # - True or truthy: logging system will be used.
+        # - None: Not output will be produced.
+        # - False or falsey: outputs to sys.stderr.
+        #   (beware: logging system may capture stderr, None may be needed!)
+
+        handler_name = self._handler_name(function)
+        msg = 'firing {hn!r} failed: {e!r}'.format(hn=handler_name, e=e)
+        if self.use_log:
+            self._log.error(msg)
+        elif self.use_log is not None:
+            sys.stderr.write('events.'+self._name+': '+msg+'\n')
+
+
+    def _handler_name(self, function):
+
+        # Return the best possible name for the function.
+        # Will be formatted like "module_name.function_name".
+
+        function_name = getattr(function, '__qualname__', None)
+        if function_name is None:
+            # Older Python versions to not support __qualname__.
+            function_name = getattr(function, '__name__', 'non-named-callable')
+
+        module_name = getattr(function, '__module__', 'non-named-module')
+
+        return '%s.%s' % (module_name, function_name)
 
 
 # ----------------------------------------------------------------------------

--- a/events/event.py
+++ b/events/event.py
@@ -1,0 +1,89 @@
+# ----------------------------------------------------------------------------
+# vim: ts=4:sw=4:et
+# ----------------------------------------------------------------------------
+# event/event.py
+# ----------------------------------------------------------------------------
+
+"""
+Simple callable based event.
+"""
+
+from __future__ import absolute_import
+
+import sys
+
+from twisted import logger
+
+
+
+class Event(object):
+
+    """
+    Callable based event with a minimal API.
+    Summary:
+    - Has zero or more handlers: functions/callables added to it.
+    - Fired by calling it, like a function.
+    - Firing it calls all associated handlers, passing them any
+      arguments given to call.
+    """
+
+    def __init__(self, name):
+
+        self._name = name
+        self._log = logger.Logger(namespace='events.%s' % (name,))
+
+        # Handler functions/callables.
+        self._functions = []
+
+
+    def calls(self, function):
+
+        """
+        Adds `function` as a handler to this event.
+        """
+
+        self._functions.append(function)
+
+
+    # There could be a "does_not_call" method to remove a known handler.
+
+
+    def __call__(self, *args, log_failures=True, **kwargs):
+
+        # Fires the event by calling all handler functions.
+
+        # `log_failures` is used to prevent usage of the logging system:
+        # This is necessary when a logging handler fires events (otherwise,
+        # any exception here would trigger a log messages, that would trigger
+        # an event, that would trigger a log messages, ad infinitum).
+
+        for function in self._functions:
+            try:
+                function(*args, **kwargs)
+            except Exception as e:
+                # Catching exceptions here is critical to ensure decoupling
+                # callables (firing events) from callees (handling events).
+
+                # Try to produce a useful message including:
+                # - The event name.
+                # - The callable name.
+                # - The raised execption.
+
+                callable_name = getattr(function, '__qualname__', None)
+                if callable_name is None:
+                    callable_name = getattr(function, '__name__', 'non-named callable')
+
+                msg = 'firing {ev!r} with {cn!r} failed: {e!r}'.format(
+                    ev=self._name,
+                    cn=callable_name,
+                    e=e,
+                )
+                if log_failures:
+                    self._log.error(msg)
+                else:
+                    sys.stderr.write(msg+'\n')
+
+
+# ----------------------------------------------------------------------------
+# event/event.py
+# ----------------------------------------------------------------------------

--- a/log/bridge.py
+++ b/log/bridge.py
@@ -27,6 +27,10 @@ class LogBridge(object):
         # Used to fire `log_message` events.
         self._event_manager = event_manager
 
+        # Tell the event manager not to use the logging system to report
+        # event handling failures; otherwise, those would come back to to us.
+        self._event_manager.log_message.use_log = None
+
 
     def __call__(self, event):
 
@@ -50,7 +54,7 @@ class LogBridge(object):
                 event.get('log_namespace', '-'),
                 logger.formatEvent(event),
             )
-            self._event_manager.log_message(msg, log_failures=False)
+            self._event_manager.log_message(msg)
 
 
 # ----------------------------------------------------------------------------

--- a/player/player_manager.py
+++ b/player/player_manager.py
@@ -40,7 +40,7 @@ class PlayerManager(object):
         """
         Initializes the player manager:
         - `reactor` is the Twisted reactor.
-        - `event_manager` is used to subscribe to `change_play_level` events.
+        - `event_manager` is used to register `change_play_level` handling.
         - `settings` is a dict with:
            - ['environment']['ld_library_path']
            - ['environment']['omxplayer_bin']
@@ -54,7 +54,7 @@ class PlayerManager(object):
         self.settings = settings
 
         # TODO: Review where/when to call this.
-        event_manager.subscribe(event_manager.change_play_level, self._change_play_level)
+        event_manager.change_play_level.calls(self._change_play_level)
 
         # part of our public interface, OMXPlayer will use this
         self.dbus_mgr = DBusManager(reactor, settings)

--- a/settings-sample.json
+++ b/settings-sample.json
@@ -6,8 +6,6 @@
     },
     "loglevel": "warn",
     "loglevels": {
-        "txdbus": "warn",
-        "events": "warn",
         "player": "warn",
         "player.dbus": "warn",
         "player.mngr": "warn",
@@ -18,7 +16,9 @@
         "inputs.arduino": "warn",
         "inputs.arduino.serial": "warn",
         "inputs.arduino.proto": "warn",
-        "webserver": "warn"
+        "webserver": "warn",
+        "txdbus": "warn",
+        "events": "warn"
     },
     "inputs": {
         "arduino": {

--- a/settings-sample.json
+++ b/settings-sample.json
@@ -7,7 +7,7 @@
     "loglevel": "warn",
     "loglevels": {
         "txdbus": "warn",
-        "events.mngr": "warn",
+        "events": "warn",
         "player": "warn",
         "player.dbus": "warn",
         "player.mngr": "warn",

--- a/webserver/websocket.py
+++ b/webserver/websocket.py
@@ -154,8 +154,8 @@ class WSFactory(websocket.WebSocketServerFactory):
         self._connected_protocol = None
         self.event_manager = event_manager
 
-        event_manager.subscribe(event_manager.arduino_raw_data, self._push_raw_data_to_client)
-        event_manager.subscribe(event_manager.log_message, self._push_log_msg_to_client)
+        event_manager.arduino_raw_data.calls(self._push_raw_data_to_client)
+        event_manager.log_message.calls(self._push_log_msg_to_client)
 
 
     def set_active_protocol(self, active_proto):


### PR DESCRIPTION
## Changed: Subscribing to events

Before:
```
event_manager.subscribe(event_manager.my_event, <handler-function>)
```

Now:
```
event_manager.my_event.calls(<handler-function>)
```

Benefits:
* Much cleaner and natural API. :)
* Resulted in a simpler underlying implementation, even though it now builds on two classes.

## Unchanged: Firing events

```
event_manager.my_event(<arguments>)
```


## Changed: Avoiding logging system on event handling failures.

Before:
```
event_manager.my_event(<args>, log_failures=False)
```

Now:
```
event_manager.my_event.use_log = False     # or None, see code comments
event_manager.my_event(<args>)
```

Benefit:
* No need to mix "event arguments" with the "extraneous" `log_failures` argument.
* Set and forget approach.

