### PR TITLE
Simpler "wiring" of raw arduino to web client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Vela 2017
-=========
+Candle 2017
+===========
 
 About
 -----
 
-**Vela 2017** is a reimplementation of an interactive art project by Nuno Godinho (https://projects.nunogodinho.com/candle/).
+**Candle 2017** is a reimplementation of an interactive art project by Nuno Godinho (https://projects.nunogodinho.com/candle/).
 
 Originally written in C++ using OpenFrameworks, Nuno never got it to run with acceptable performance on the desired target platform, a Raspberri Pi; it required being driven by a much more powerful and expensive system, like a Mac Mini.
 
@@ -125,7 +125,7 @@ $
 * Track log messages on the top right pane.
 * Use the buttons on the bottom to trigger video level changes.
 
-> Important: multiple browser connections are accepted simultaneously, however only the *most recent connection* will actually be usable; also, no authentication is in place.
+> Important: multiple browser connections are accepted simultaneously; no effort to authenticate or limit the amount of connections is made.
 
 
 Configuration

--- a/events/event.py
+++ b/events/event.py
@@ -42,13 +42,19 @@ class Event(object):
     def calls(self, function):
 
         """
-        Adds `function` as a handler to this event.
+        Adds `function` as an event handler.
         """
 
         self._functions.append(function)
 
 
-    # There could be a "does_not_call" method to remove a known handler.
+    def no_longer_calls(self, function):
+
+        """
+        Removes `function` from exising event handlers.
+        """
+
+        self._functions.remove(function)
 
 
     def __call__(self, *args, **kwargs):

--- a/webserver/web-root/index.html
+++ b/webserver/web-root/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>websocket sourced chart</title>
+    <title>Candle 2017</title>
     <script type="text/javascript" src="Chart.bundle.min.js">
     </script>
     <script type="text/javascript" src="chartjs-plugin-annotation.min.js">

--- a/webserver/websocket.py
+++ b/webserver/websocket.py
@@ -39,8 +39,6 @@ class WSProto(websocket.WebSocketServerProtocol):
 
         # Twisted/Autobahn calls this when a websocket connection is establised.
 
-        _log.info('ws conn')
-
         # Add self as a log observer to push logs to the client.
         log.add_observer(self)
 
@@ -52,7 +50,7 @@ class WSProto(websocket.WebSocketServerProtocol):
 
         # Twisted/Autobahn calls this when a websocket connection is ready.
 
-        _log.info('ws open')
+        _log.info('{p.host}:{p.port} connected', p=self.transport.getPeer())
 
 
     def onMessage(self, payload, isBinary):
@@ -111,7 +109,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         # Can't push arduino raw data to the client anymore.
         self.factory.event_manager.arduino_raw_data.no_longer_calls(self._push_raw_data)
 
-        _log.info('ws clse')
+        _log.info('{p.host}:{p.port} disconnected', p=self.transport.getPeer())
 
 
     def _send_message_dict(self, message_type, message_dict):


### PR DESCRIPTION
Picked up on the dynamic "subscribe"/"unsubscribe" idea from #54 and applied the same principles.

Benefits:
* Much simpler websocket server side code:
  * Protocol "subscribes" on connect, "unsubscribes" on disconnect.
  * Factory / Protocols no longer track "connected protocol".

Side effect:
* Multiple simultaneous web clients now supported: not necessarily good, but not bad, also.
* Given that, updated websocket logging to include IP+PORT of web client connections/disconnections.

Along the way:
* Updated the README:
  * Multiple simultaneous web clients supported.
  * s/Vela/Candle, because it was "right there asking for it".
* Added a "proper" title to the HTML interface page (silly Safari doesn't show it by default when using single tabbed windows).

Benefit:
* Simpler code.
* Less code.