### PR TITLE
Web client: reordered "set log level" HTML selector order.

### DIFF
--- a/inputs/web/web-root/index.html
+++ b/inputs/web/web-root/index.html
@@ -113,9 +113,9 @@
                         <select id="logger_namespace">
                             <option value="">all loggers</option>
                             <option value="inputs">inputs</option>
-                            <option value="inputs.agd">inputs.agd</option>
                             <option value="inputs.arduino">inputs.arduino</option>
                             <option value="inputs.audio">inputs.audio</option>
+                            <option value="inputs.agd">inputs.agd</option>
                             <option value="inputs.network">inputs.network</option>
                             <option value="inputs.web">inputs.web</option>
                             <option value="player">player</option>
@@ -125,10 +125,10 @@
                             <option value="player.each">player.each</option>
                         </select>
                         <select id="logger_level">
-                            <option value="debug">debug</option>
-                            <option value="info" selected="selected">info</option>
-                            <option value="warn">warn</option>
                             <option value="error">error</option>
+                            <option value="warn">warn</option>
+                            <option value="info" selected="selected">info</option>
+                            <option value="debug">debug</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Changes:
* Logger name selector: `input.agd` more naturally after `input.arduino` and `input.audio`.
* Log level selector: reversed the order having `error`, `warning`, `info` and `debug` from the top downwards.

Didn't change any names as these sound fine. Maybe in the context of #23 some changes come up.

Mergint this fixes #53.