### PR TITLE
Inputs can now be enabled/disabled from settings.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Sets the default logging level for each internal component. These can be changed
 
 ### Inputs
 
-The `inputs` key is a list/array of dicts/objects and it should contain one or more entries specifying the inputs to be used. Each such entry will have an `input_type` key/property with the remaining keys/properties depending on that setting (which, for readability, are referenced below as `inputs.<input_type>.*`).
+The `inputs` key is a list/array of dicts/objects containing one or more entries specifying the inputs to be used. Each such entry must have a `type` key/property, with the remaining keys/properties depending on that setting (which, for readability, are referenced below as `inputs.<type>.*`); additionally, each entry can be individually enabled/disabled depending on the boolean value of the `enabled` key/property.
 
 Limitation: the `web` input needs to be declared before `agd`, if used: otherwise, AGD threshold web based management does not operate properly.
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Limitation: the `web` input needs to be declared before `agd`, if used: otherwis
 
 | setting                          | description                                                     |
 |----------------------------------|-----------------------------------------------------------------|
-| inputs.agd.source                | Input sensor source name: one of `arduino` or `audio`.          |
+| inputs.agd.source                | Input sensor source name: one of `arduino`, `audio` or `hid`.   |
 | inputs.agd.buffer_size           | Input processor buffer size.                                    |
 | inputs.agd.thresholds            | Input processor thresholds: adjusts "input sensor" responsiveness. |
 

--- a/inputs/input_manager.py
+++ b/inputs/input_manager.py
@@ -65,7 +65,10 @@ class InputManager(object):
 
         _log.info('starting')
         for input_item in self._settings['inputs']:
-            input_type = input_item.pop('input_type', None)
+            input_type = input_item.pop('type', None)
+            enabled = input_item.pop('enabled', False)
+            if not enabled:
+                continue
             try:
                 input_class = _INPUT_CLASSES[input_type]
             except KeyError:

--- a/settings-sample.json
+++ b/settings-sample.json
@@ -25,23 +25,27 @@
     },
     "inputs": [
         {
-            "input_type": "web",
+            "type": "web",
+            "enabled": true,
             "interface": "0.0.0.0",
             "port": 8080
         },
         {
-            "input_type": "agd",
+            "type": "agd",
+            "enabled": false,
             "buffer_size": 25,
             "thresholds": [7, 20, 30],
             "source": "arduino"
         },
         {
-            "input_type": "arduino",
+            "type": "arduino",
+            "enabled": false,
             "device_file": "/dev/ttyACM0",
             "baud_rate": 9600
         },
         {
-            "input_type": "audio",
+            "type": "audio",
+            "enabled": false,
             "nice_bin": "/usr/bin/nice",
             "arecord_bin": "/usr/bin/arecord",
             "device": "hw:CARD=H2300,DEV=0",
@@ -52,16 +56,18 @@
             "respawn_delay": 1
         },
         {
-            "input_type": "hid",
+            "type": "hid",
+            "enabled": false,
             "device_file": "/dev/input/event0",
-            "reading_event_name": "ABS_Y",
+            "reading_event_code": "ABS_Y",
             "reading_scale": 1,
             "reading_offset": 0,
             "period": 0.1
 
         },
         {
-            "input_type": "network",
+            "type": "network",
+            "enabled": false,
             "port": 10000
         }
     ],

--- a/settings-sample.json
+++ b/settings-sample.json
@@ -31,13 +31,6 @@
             "port": 8080
         },
         {
-            "type": "agd",
-            "enabled": false,
-            "buffer_size": 25,
-            "thresholds": [7, 20, 30],
-            "source": "arduino"
-        },
-        {
             "type": "arduino",
             "enabled": false,
             "device_file": "/dev/ttyACM0",
@@ -64,6 +57,13 @@
             "reading_offset": 0,
             "period": 0.1
 
+        },
+        {
+            "type": "agd",
+            "enabled": false,
+            "buffer_size": 25,
+            "thresholds": [7, 20, 30],
+            "source": "arduino"
         },
         {
             "type": "network",


### PR DESCRIPTION
Addresses #81.

Other changes:
* Updated the `input_type` key to `type` to better go along with the new `enabled` key.
* Updated README.
