### PR TITLE
Updated wires to 18.1.0b2: simpler, more direct API.

### DIFF
--- a/candle2017.py
+++ b/candle2017.py
@@ -68,9 +68,9 @@ def start_things(reactor, settings):
     log.setup(level=log_level, namespace_levels=log_levels)
 
 
-    # Create a call wiring object and tell it what to with `set_log_level` events.
-    wiring = wires.Wires()
-    wiring.wire.set_log_level.calls_to(log.set_level)
+    # Create a call wiring object and tell it what to with `set_log_level` calls.
+    wiring = wires.Wiring()
+    wiring.set_log_level.wire(log.set_level)
 
 
     # Create the input and player managers.

--- a/inputs/agd/input.py
+++ b/inputs/agd/input.py
@@ -44,12 +44,11 @@ class AggregatedDerivative(input_base.InputBase):
         self._last_play_level = 0
 
         # Handle the output produced by the selected input `source`.
-        # TODO: wires should allow "wiring.wire[source].calls_to(...)"
-        getattr(wiring.wire, source).calls_to(self._input_received)
+        wiring[source].wire(self._input_received)
 
         # Handle requests to get/set AGD thresholds.
-        wiring.wire.request_agd_thresholds.calls_to(self._notify_agd_thresholds)
-        wiring.wire.set_agd_threshold.calls_to(self._set_threshold)
+        wiring.request_agd_thresholds.wire(self._notify_agd_thresholds)
+        wiring.set_agd_threshold.wire(self._set_threshold)
 
 
     @defer.inlineCallbacks

--- a/inputs/web/server.py
+++ b/inputs/web/server.py
@@ -43,7 +43,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         log_package.add_observer(self)
 
         # Handle `agd_output` by pushing it as chart data to the client.
-        self.factory.wiring.wire.agd_output.calls_to(self._push_chart_data)
+        self.factory.wiring.agd_output.wire(self._push_chart_data)
 
 
     def onOpen(self):
@@ -53,7 +53,7 @@ class WSProto(websocket.WebSocketServerProtocol):
         _log.warn('{p.host}:{p.port} connected', p=self.transport.getPeer())
 
         # Handle AGD threshold notifications by pushing them to the client.
-        self.factory.wiring.wire.notify_agd_threshold.calls_to(
+        self.factory.wiring.notify_agd_threshold.wire(
             self._push_agd_threshold
         )
 
@@ -126,10 +126,10 @@ class WSProto(websocket.WebSocketServerProtocol):
         log_package.remove_observer(self)
 
         # Can't push chart data to the client anymore.
-        self.factory.wiring.unwire.agd_output.calls_to(self._push_chart_data)
+        self.factory.wiring.agd_output.unwire(self._push_chart_data)
 
         # Can't push threshold updates to the client anymore.
-        self.factory.wiring.unwire.notify_agd_threshold.calls_to(
+        self.factory.wiring.notify_agd_threshold.unwire(
             self._push_agd_threshold
         )
 

--- a/player/player_manager.py
+++ b/player/player_manager.py
@@ -134,7 +134,7 @@ class PlayerManager(object):
         yield self.players[0].play()
 
         # Ready to respond to change level requests.
-        self._wiring.wire.change_play_level.calls_to(self._change_play_level)
+        self._wiring.change_play_level.wire(self._change_play_level)
 
         self.log.info('started')
 
@@ -229,7 +229,7 @@ class PlayerManager(object):
         self.log.info('stopping')
 
         self._stopping = True
-        self._wiring.unwire.change_play_level.calls_to(self._change_play_level)
+        self._wiring.change_play_level.unwire(self._change_play_level)
         for level, player in self.players.items():
             self.log.info('stopping player level={l!r}', l=level)
             yield player.stop(skip_dbus)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,6 @@ six==1.11.0
 Twisted==17.9.0
 txaio==2.9.0
 txdbus==1.1.0
-wires==18.1.0b1
+wires==18.1.0b2
 wrapt==1.10.11
 zope.interface==4.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ six==1.11.0
 Twisted==17.9.0
 txaio==2.9.0
 txdbus==1.1.0
-wires==18.1.0b1
+wires==18.1.0b2
 zope.interface==4.4.3


### PR DESCRIPTION
This addresses #79 but please don't merge yet, the dependency in `requirements.txt` is still on version 18.1.0b2.

Once 18.1.0 is released and the dependency is set, we'll merge this.